### PR TITLE
Fix for 2 threads

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ notifications:
  email: false
 script:
  - if [[ -a .git/shallow ]]; then git fetch --unshallow; fi
- - julia -e 'Pkg.clone(pwd()); Pkg.build("SALSA"); Pkg.test("SALSA"; coverage=true)'
- - julia -e 'Pkg.add("Lint"); using Lint; lintpkg("SALSA",returnMsgs=true)'
+ - julia -p 2 -e 'Pkg.clone(pwd()); Pkg.build("SALSA"); Pkg.test("SALSA"; coverage=true)'
+ - julia -p 2 -e 'Pkg.add("Lint"); using Lint; lintpkg("SALSA",returnMsgs=true)'
 after_success:
- - julia -e 'cd(Pkg.dir("SALSA")); Pkg.add("Coverage"); using Coverage; Coveralls.submit(Coveralls.process_folder())'
+ - julia -p 2 -e 'cd(Pkg.dir("SALSA")); Pkg.add("Coverage"); using Coverage; Coveralls.submit(Coveralls.process_folder())'

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ notifications:
  email: false
 script:
  - if [[ -a .git/shallow ]]; then git fetch --unshallow; fi
- - julia -p 2 -e 'Pkg.clone(pwd()); Pkg.build("SALSA"); Pkg.test("SALSA"; coverage=true)'
- - julia -p 2 -e 'Pkg.add("Lint"); using Lint; lintpkg("SALSA",returnMsgs=true)'
+ - julia -e 'Pkg.clone(pwd()); Pkg.build("SALSA"); Pkg.test("SALSA"; coverage=true)'
+ - julia -e 'Pkg.add("Lint"); using Lint; lintpkg("SALSA",returnMsgs=true)'
 after_success:
- - julia -p 2 -e 'cd(Pkg.dir("SALSA")); Pkg.add("Coverage"); using Coverage; Coveralls.submit(Coveralls.process_folder())'
+ - julia -e 'cd(Pkg.dir("SALSA")); Pkg.add("Coverage"); using Coverage; Coveralls.submit(Coveralls.process_folder())'

--- a/src/support/validation_support.jl
+++ b/src/support/validation_support.jl
@@ -7,7 +7,7 @@ mse(y, yhat) = sse(y, yhat)/length(yhat)
 # Area Under ROC surve with latent output y
 auc(y, ylat; n=100) = std(ylat[:]) == 0 ? 0.0 : auc(roc(round(Int,y)[:], ylat[:], n))
 # provide convenient function for parallalizing cross-validation
-nfolds() = if nworkers() == 1 || nworkers() > 10 10 else nworkers() end
+nfolds() = if nprocs() == 1 || nprocs() > 10 10 else nprocs() end
 # helper function for AUC calculus
 function auc(roc::Array{ROCNums{Int}})
 	total_auc = zero(Float64)


### PR DESCRIPTION
nworkers() returns the number of available processes-1, or 1 if the number of processes is 1. This causes scripts run with "julia -p 2" to behave strangely.

I believe that we actually want to use nprocs(), which is the number of available processes. This causes "julia -p 2" to work as expected.
