### PR TITLE
Nearly 0.6 compatible. Having some difficulties with usage of sub()

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -1,4 +1,4 @@
-julia 0.4
+julia 0.6
 MAT
 MLBase
 Compat

--- a/src/SALSA.jl
+++ b/src/SALSA.jl
@@ -58,6 +58,7 @@ export salsa,
     loss_derivative,
     membership,
     DelimitedFile,
+    sub,
     # global optimization
     CSA, DS, GlobalOpt,
     csa, ds,
@@ -82,11 +83,10 @@ export salsa,
 
 
 using MLBase, Distributions, Compat, Distances, Clustering, ProgressMeter
-import Base: size, getindex, issparse, sub, dot, show, isempty, At_mul_B!, readline
+import Base: size, getindex, issparse, dot, show, isempty, At_mul_B!, readline
 import StatsBase: counts, predict
 import LegacyStrings: UTF32String
 import ArrayViews: view
-
 # needed support files
 include(joinpath("support", "data_wrapper.jl"))
 include(joinpath("support", "definitions.jl"))

--- a/src/SALSAModel.jl
+++ b/src/SALSAModel.jl
@@ -15,10 +15,10 @@
 # GNU General Public License for more details.
 #
 
-abstract Model
+abstract type Model end
 
-abstract Loss 
-abstract NonParametricLoss <: Loss
+abstract type Loss end 
+abstract type NonParametricLoss <: Loss end
 immutable HINGE <: NonParametricLoss end
 immutable LOGISTIC <: NonParametricLoss end
 immutable SQUARED_HINGE <: NonParametricLoss end
@@ -26,9 +26,9 @@ immutable MODIFIED_HUBER <: NonParametricLoss end
 immutable LEAST_SQUARES <: NonParametricLoss end
 immutable PINBALL <: Loss end
 
-abstract Algorithm 
-abstract RDA <: Algorithm
-abstract SGD <: Algorithm
+abstract type Algorithm end 
+abstract type RDA <: Algorithm end
+abstract type SGD <: Algorithm end
 immutable PEGASOS <: SGD end
 immutable L1RDA <: RDA end
 immutable R_L1RDA <: RDA end
@@ -48,7 +48,7 @@ RK_MEANS(k_clusters::Int) = RK_MEANS(PEGASOS,k_clusters,20,Euclidean())
 RK_MEANS{A <: Algorithm}(support_alg::Type{A}, model::RK_MEANS) = RK_MEANS(support_alg,model.k_clusters,model.max_iter,model.metric)
 RK_MEANS{M <: SemiMetric}(metric::M, model::RK_MEANS) = RK_MEANS(model.support_alg,model.k_clusters,model.max_iter,metric)
 
-abstract Mode
+abstract type Mode end
 immutable LINEAR <: Mode end
 immutable NONLINEAR <: Mode
     k_params::Vector
@@ -81,7 +81,7 @@ type OutputModel{M <: Mode}
 	cv_n_f::Int
 	cv_n::Int
 	
-    OutputModel() = new()
+    OutputModel{M}() where {M<:Mode} = new()
 end
 
 type SALSAModel{L <: Loss, A <: Algorithm, 

--- a/src/algorithms/adaptive_l1rda_alg.jl
+++ b/src/algorithms/adaptive_l1rda_alg.jl
@@ -58,15 +58,15 @@ function adaptive_l1rda_alg(dfunc::Function, X, Y, λ::Float64, γ::Float64, ρ:
         # find a close form solution
         if check
             h = t>1 ? h + g_new.^2 : ρ .+ g_new.^2
-            w = -(t*γ./sqrt(h)).*(g - λ.*sign(g))
-            w[abs(g).<=λ] = 0
+            w = -(t*γ./sqrt(h)).*(g - λ.*sign.(g))
+            w[abs.(g).<=λ] = 0
         else
             # do not perform sparse(...) and filter and map over SparceMatrixCSC
             # because Garbage Collection performs realy badly in the tight loops
             h = t>1 ? h + g_new.^2 : sparse(ρ+g_new.^2)
             h_sq = SparseMatrixCSC(d,1,h.colptr,h.rowval,-(t*γ)./sqrt(h.nzval))
-            gs = SparseMatrixCSC(d,1,g.colptr,g.rowval,sign(g.nzval))
-            w = h_sq.*(g - λ.*gs); ind = abs(g.nzval) .> λ
+            gs = SparseMatrixCSC(d,1,g.colptr,g.rowval,sign.(g.nzval))
+            w = h_sq.*(g - λ.*gs); ind = abs.(g.nzval) .> λ
             w = isempty(ind) ? w_prev : reduce_sparsevec(w,find(ind))
         end
 

--- a/src/algorithms/l1rda_alg.jl
+++ b/src/algorithms/l1rda_alg.jl
@@ -55,13 +55,13 @@ function l1rda_alg(dfunc::Function, X, Y, λ::Float64, γ::Float64, ρ::Float64,
 
         # find a close form solution
         if check
-            w = -(sqrt(t)/γ).*(g - λ_rda.*sign(g))
-            w[abs(g).<=λ_rda] = 0
+            w = -(sqrt(t)/γ).*(g - λ_rda.*sign.(g))
+            w[abs.(g).<=λ_rda] = 0
         else
             # do not perform sparse(...) and filter and map over SparceMatrixCSC
             # because Garbage Collection performs realy badly in the tight loops
-            gs = SparseMatrixCSC(d,1,g.colptr,g.rowval,sign(g.nzval))
-            w = -(sqrt(t)/γ).*(g - λ_rda.*gs); ind = abs(g.nzval) .> λ_rda
+            gs = SparseMatrixCSC(d,1,g.colptr,g.rowval,sign.(g.nzval))
+            w = -(sqrt(t)/γ).*(g - λ_rda.*gs); ind = abs.(g.nzval) .> λ_rda
             w = isempty(ind) ? w_prev : reduce_sparsevec(w,find(ind))
         end
 

--- a/src/algorithms/reweighted_l1rda_alg.jl
+++ b/src/algorithms/reweighted_l1rda_alg.jl
@@ -56,17 +56,17 @@ function reweighted_l1rda_alg(dfunc::Function, X, Y, λ::Float64, γ::Float64, �
         # find a close form solution
         if check
             λ_rda = rw*λ .+ (ρ*γ)/sqrt(t)
-            w = -(sqrt(t)/γ).*(g - λ_rda.*sign(g))
-            w[abs(w).<=λ_rda] = 0
-            rw = 1 ./ (abs(w) .+ ɛ)
+            w = -(sqrt(t)/γ).*(g - λ_rda.*sign.(g))
+            w[abs.(w).<=λ_rda] = 0
+            rw = 1 ./ (abs.(w) .+ ɛ)
         else
             # do not perform sparse(...) and filter and map over SparceMatrixCSC
             # because Garbage Collection performs realy badly in the tight loops
-            λ_f = (v) -> λ./(abs(v) .+ ɛ) .+ (ρ*γ)/sqrt(t)
-            gs = SparseMatrixCSC(d,1,g.colptr,g.rowval,sign(g.nzval))
+            λ_f = (v) -> λ./(abs.(v) .+ ɛ) .+ (ρ*γ)/sqrt(t)
+            gs = SparseMatrixCSC(d,1,g.colptr,g.rowval,sign.(g.nzval))
             λ_rda = SparseMatrixCSC(d,1,w.colptr,w.rowval,λ_f(w.nzval))
             w = -(sqrt(t)/γ).*(g - λ_rda.*gs); I,J,V = findnz(g)
-            ind = abs(V) .> λ_f(full(w_prev[I]))
+            ind = abs.(V) .> λ_f(full(w_prev[I]))
             w = isempty(ind) ? w_prev : reduce_sparsevec(w,find(ind))
         end
 

--- a/src/algorithms/reweighted_l2rda_alg.jl
+++ b/src/algorithms/reweighted_l2rda_alg.jl
@@ -74,9 +74,9 @@ function reweighted_l2rda_alg(dfunc::Function, X, Y, λ::Float64, ɛ::Float64, v
 
     # truncate solution
     if check
-        w[abs(w).<=varɛ] = 0
+        w[abs.(w).<=varɛ] = 0
     else
-        ind = abs(w.nzval) .> varɛ
+        ind = abs.(w.nzval) .> varɛ
         w = isempty(ind) ? w : reduce_sparsevec(w,find(ind))
     end
 

--- a/src/kernels/kernels.jl
+++ b/src/kernels/kernels.jl
@@ -15,7 +15,7 @@
 # GNU General Public License for more details.
 #
 
-abstract Kernel
+abstract type Kernel end
 
 kernel_matrix(k::Kernel, X::Matrix) = kernel_matrix(k, X, X)
 kernel_matrix(k::Kernel, X::Array{Float64,1}) = kernel_matrix(k, X')

--- a/src/loss_derivative.jl
+++ b/src/loss_derivative.jl
@@ -35,7 +35,7 @@ function modified_huber_loss_derivative(At,yt,w)
   deriv = init(At)
 
   idx1 = find(eval.<-1)
-  idx2 = find((eval.>=-1)&(eval.<1))
+  idx2 = find((eval.>=-1).&(eval.<1))
 
   if ~isempty(idx1)
     deriv += 4*hinge_loss(At,yt,idx1)
@@ -95,9 +95,9 @@ pinball_loss_derivative{T <: Number, AV <: AbstractVector}(At::AV,yt::T,w,τ) = 
 pinball_loss_derivative{T <: Number, M <: AbstractSparseArray}(At::M,yt::T,w,τ) = evaluate(At,yt,w)[1] < 1 ? -At.*yt : τ*At.*yt
 
 # LOGISTIC LOSS
-logistic_loss{T <: Number}(At,yt::T,w,eval=evaluate(At,yt,w)) = -At.*yt/(exp(eval)+1)
-logistic_loss(At::Matrix,yt,w,eval=evaluate(At,yt,w)) = -sum(At.*repmat((yt./(exp(eval)+1))',size(At,1),1),2)
-logistic_loss{T <: AbstractSparseArray}(At::T,yt,w,eval=evaluate(At,yt,w)) = reduce((d0,i) -> d0 - (At[:,i] .* (yt[i]/(exp(eval[i])+1))), spzeros(size(At,1),1), 1:1:size(At,2))
+logistic_loss{T <: Number}(At,yt::T,w,eval=evaluate(At,yt,w)) = -At.*yt/(exp.(eval)+1)
+logistic_loss(At::Matrix,yt,w,eval=evaluate(At,yt,w)) = -sum(At.*repmat((yt./(exp.(eval)+1))',size(At,1),1),2)
+logistic_loss{T <: AbstractSparseArray}(At::T,yt,w,eval=evaluate(At,yt,w)) = reduce((d0,i) -> d0 - (At[:,i] .* (yt[i]/(exp.(eval[i])+1))), spzeros(size(At,1),1), 1:1:size(At,2))
 
 # LEAST-SQUARES LOSS
 least_squares_loss(At::Matrix,yt,w) = At*(evaluate(At,w) - yt)

--- a/src/predict.jl
+++ b/src/predict.jl
@@ -16,7 +16,7 @@
 #
 
 # Predict by evaluating a simple linear model
-predict_raw(model::SALSAModel,X) = sign(predict_latent_raw(model,X))
+predict_raw(model::SALSAModel,X) = sign.(predict_latent_raw(model,X))
 predict_latent_raw(model::SALSAModel,X) = X*model.output.w .+ ones(size(X,1),1)*model.output.b
 predict_by_distance_raw(model::SALSAModel,X) = membership(1 .- pairwise(model.algorithm.metric, X', model.output.w))
 # aliases to predict according to validation criterion and task: regression/classification
@@ -25,8 +25,8 @@ predict(criterion::MISCLASS, model::SALSAModel, X) 	 = predict_raw(model, X)
 predict(criterion::MSE, model::SALSAModel, X) 	  	 = predict_latent_raw(model, X)
 predict(criterion::SILHOUETTE, model::SALSAModel, X) = predict_by_distance_raw(model, X)
 
-predict_raw(model::SALSAModel,f::DelimitedFile) = vcat([predict_raw(model,sub(f,i,:)) for i=1:count(f)]...)
-predict_latent_raw(model::SALSAModel,f::DelimitedFile) = vcat([predict_latent_raw(model,sub(f,i,:)) for i=1:count(f)]...)
+predict_raw(model::SALSAModel,f::DelimitedFile) = vcat([predict_raw(model,view(f,i,:)) for i=1:count(f)]...)
+predict_latent_raw(model::SALSAModel,f::DelimitedFile) = vcat([predict_latent_raw(model,view(f,i,:)) for i=1:count(f)]...)
 
 function predict(model::SALSAModel,X)
 	if model.mode == LINEAR

--- a/src/qa_tables/QAModel.jl
+++ b/src/qa_tables/QAModel.jl
@@ -15,14 +15,14 @@
 # GNU General Public License for more details.
 #
 
-abstract QANode
+abstract type QANode end
 
 type LinearQANode <: QANode
-	question:: UTF32String
+	question:: String
 	procfunc:: Function
 	# field not provided by default at instantiation
 	options:: Dict
-	answer:: ASCIIString
+	answer:: String
 end
 
 immutable QAOption{N <: QANode}

--- a/src/support/constants.jl
+++ b/src/support/constants.jl
@@ -15,8 +15,8 @@
 # GNU General Public License for more details.
 #
 
-abstract Criterion 
-abstract CCriterion <: Criterion
+abstract type Criterion end 
+abstract type CCriterion <: Criterion end
 immutable MSE <: CCriterion end
 immutable MISCLASS <: CCriterion end 
 immutable SILHOUETTE <: Criterion end 
@@ -24,11 +24,11 @@ immutable AUC <: CCriterion
 	n_thresholds::Integer
 end
 
-abstract GlobalOpt 
+abstract type GlobalOpt end 
 immutable CSA <: GlobalOpt end 
 immutable DS <: GlobalOpt
 	init_params::Vector 
 end
 
-DS() = DS(Array(Float64,0))
+DS() = DS(Array{Float64}(0))
 AUC() = AUC(100)

--- a/src/support/csa.jl
+++ b/src/support/csa.jl
@@ -63,23 +63,23 @@ function csa(obj_fun, pn)
         @showprogress 1 "Running hyperparameter tuning... " 20 for l = 1:NI
             # choose new coordinates and compute
             # the function to minimize
-            r = tan(pi*(rand(pdim,pnum).-0.5));
+            r = tan.(pi*(rand(pdim,pnum).-0.5));
             # ****************** Wrapping ***************
             #pn = 2*mod((p0 + r * T + 1)/2,1)-1;
             #**************** Non wrapping *************
              pn = p0 + r * T ;#* (diag(e0)./sum(e0));
-             indd = find(abs(pn).>10);
+             indd = find(abs.(pn).>10);
              while length(indd) > 0
-                 r[indd] = tan(pi*(rand(size(indd)).-0.5));
+                 r[indd] = tan.(pi*(rand(size(indd)).-0.5));
                  pn = p0 + r * T ;#* (diag(e0)./sum(e0));
-                 indd = find(abs(pn).>15);
+                 indd = find(abs.(pn).>15);
              end
 
             en = convert(Array{Float64}, obj_fun(pn))
 
-            Esum = sum(exp((e0.-maximum(e0))./Tac));
+            Esum = sum(exp.((e0.-maximum(e0))./Tac));
             for i=1:pnum
-                pblty[i] = min(1.0,exp((e0[i]-maximum(e0))/Tac)/Esum);
+                pblty[i] = min(1.0,exp.((e0[i]-maximum(e0))/Tac)/Esum);
                 if pblty[i] > 1
                     pblty[i] = 1.
                 end

--- a/src/support/data_wrapper.jl
+++ b/src/support/data_wrapper.jl
@@ -15,7 +15,7 @@
 # GNU General Public License for more details.
 #
 
-abstract DataWrapper
+abstract type DataWrapper end
 type DelimitedFile <: DataWrapper
 	name::String
 	header::Bool

--- a/src/tune_algorithm_AFEm.jl
+++ b/src/tune_algorithm_AFEm.jl
@@ -39,8 +39,8 @@ function cross_validate_algorithm_AEFm(x0, X, Y, model, num_k, X_subset)
     
     # perform cross-validation by a generic and parallelizable function
     gen_cross_validate(size(Y,1), model) do train_idx, val_idx
-        Xtr, Ytr   = sub(X,train_idx,:), sub(Y,train_idx,:)
-        Xval, Yval = sub(X,val_idx,:), sub(Y,val_idx,:)
+        Xtr, Ytr   = view(X,train_idx,:), view(Y,train_idx,:)
+        Xval, Yval = view(X,val_idx,:), view(Y,val_idx,:)
         # perform Automatic Feature Extraction by Nystrom approximation 
         features_train = AFEm(eigvals,eigvec,X_subset,kernel,Xtr)
         features_valid = AFEm(eigvals,eigvec,X_subset,kernel,Xval)        

--- a/src/validation_criteria.jl
+++ b/src/validation_criteria.jl
@@ -15,7 +15,7 @@
 # GNU General Public License for more details.
 #
 
-validation_criterion(model::SALSAModel,X,Y,val_idx) = validation_criterion(model,sub(X,val_idx,:)[:,:],Y[val_idx])
+validation_criterion(model::SALSAModel,X,Y,val_idx) = validation_criterion(model, view(X,val_idx,:)[:,:],Y[val_idx])
 validation_criterion{L <: Loss, A <: SGD}(model::SALSAModel{L,A},X,Y) = validation_criterion(model.validation_criterion,model,X,Y)
 validation_criterion{L <: Loss, A <: RK_MEANS}(model::SALSAModel{L,A},X,Y) = validation_criterion(model.validation_criterion,model,X,Y)
 validation_criterion{L <: Loss, A <: RDA}(model::SALSAModel{L,A},X,Y) = model.sparsity_cv*mean(model.output.w .!= 0) + (1-model.sparsity_cv)*validation_criterion(model.validation_criterion,model,X,Y)

--- a/test/functional/qa_tables/test_qa.jl
+++ b/test/functional/qa_tables/test_qa.jl
@@ -15,7 +15,7 @@ run_model = (X,Y,model,Xtest) -> begin
 end
 
 show(salsa_qa(eye(10),read_char,read_int,run_model))
-s = utf8(readavailable(outRead))
+s = String(readavailable(outRead))
 
 #test Q/A table contents
 @test contains(s, "Computing the model..")

--- a/test/unit/test_loss_derivative.jl
+++ b/test/unit/test_loss_derivative.jl
@@ -3,34 +3,38 @@ using SALSA, Base.Test
 loss = loss_derivative(HINGE)
 @test loss([1;2],-1,[2;1]) == [1;2]
 @test loss([1;2],1,[2;1])  == zeros(2,1)
-@test loss([1 1;2 2],[-1,-1],[2;1]) == [2,4]''
-@test loss(sparse([1;2]),[-1],sparse([2;1])) == sparse([1;2]'')
+#The old test was loss([1 1;2 2],[-1,-1],[2;1]) == [10,20]''
+#However '' no longer changes an array of length n to a nx1 array
+@test loss([1 1;2 2],[-1,-1],[2;1]) == reshape([2,4], :, 1)
+@test loss(sparse([1;2]),[-1],sparse([2;1])) == sparse(reshape([1;2], :, 1))
 
 loss = loss_derivative(SQUARED_HINGE)
 @test loss([1;2],-1,[2;1]) == [5;10]
 @test loss([1;2],1,[2;1])  == zeros(2,1)
-@test loss([1 1;2 2],[-1,-1],[2;1]) == [10,20]''
-@test loss(sparse([1;2]),[-1],sparse([2;1])) == sparse([5;10]'')
+#The old test was loss([1 1;2 2],[-1,-1],[2;1]) == [10,20]''
+#However '' no longer changes an array of length n to a nx1 array
+@test loss([1 1;2 2],[-1,-1],[2;1]) == reshape([10,20], :, 1)
+@test loss(sparse([1;2]),[-1],sparse([2;1])) == sparse(reshape([5;10], :, 1))
 
 loss = loss_derivative(PINBALL,.5)
 @test loss([1;2],-1,[2;1]) == [1;2]
 @test loss([1;2],1,[2;1])  == [1;2].*.5
-@test loss([1 2;2 1],[-1,1],[2;1]) == [2,2.5]''
-@test loss(sparse([1;2]),[-1],sparse([2;1])) == sparse([1;2]'')
+@test loss([1 2;2 1],[-1,1],[2;1]) == reshape([2,2.5], :, 1)
+@test loss(sparse([1;2]),[-1],sparse([2;1])) == sparse(reshape([1;2], :, 1))
 
 loss = loss_derivative(LOGISTIC)
 @test loss([1;2],-1,[2;1]) == [0.9820137900379085,1.964027580075817]
 @test loss([1;2],1,[2;1])  == [-0.01798620996209156,-0.03597241992418312]
-@test loss([1 2;2 1],[-1,1],[2;1]) == [0.9686280881893388,1.957334729151532]''
-@test loss(sparse([1;2]),[-1],sparse([2;1])) == sparse([0.9820137900379085,1.964027580075817]'')
+@test loss([1 2;2 1],[-1,1],[2;1]) == reshape([0.9686280881893388,1.957334729151532], :, 1)
+@test loss(sparse([1;2]),[-1],sparse([2;1])) == sparse(reshape([0.9820137900379085,1.964027580075817], :, 1))
 
 loss = loss_derivative(LEAST_SQUARES)
 @test loss([1;2],-1,[2;1]) == [5,10]
 @test loss([1;2],1,[2;1])  == [3,6]
 @test loss([1 2;2 1],[-1,1],[2;1]) == [13,14]
-@test loss(sparse([1;2]),[-1],sparse([2;1])) == sparse([5,10]'')
+@test loss(sparse([1;2]),[-1],sparse([2;1])) == sparse(reshape([5,10], :, 1))
 
 loss = loss_derivative(MODIFIED_HUBER)
-@test loss([1;2],-1,[2;1]) == [4,8]''
-@test loss([1;2],1,[.1;.1]) == [-.7,-1.4]''
-@test loss([1 1;2 2],[-1,1],[.1;.2]) == [1,2]''
+@test loss([1;2],-1,[2;1]) == reshape([4,8], :, 1)
+@test loss([1;2],1,[.1;.1]) == reshape([-.7,-1.4], :, 1)
+@test loss([1 1;2 2],[-1,1],[.1;.2]) == reshape([1,2], :, 1)

--- a/test/unit/test_show.jl
+++ b/test/unit/test_show.jl
@@ -6,7 +6,7 @@ model = SALSAModel(LINEAR,PEGASOS(),HINGE)
 model.output.dfunc = loss_derivative(HINGE)
 show(outWrite, model)
 
-s = utf8(readavailable(outRead))
+s = String(readavailable(outRead))
 redirect_stdout(outOriginal)
 
 @test contains(s,"SALSA model:")


### PR DESCRIPTION
This removes almost all of the deprecation notices and issues between the old version and 0.6. 

There is a slight problem with the usage of `sub()`. It seems like it should be possible to replace `sub()` with `view()`. However, I noticed that the original maintainer had a note concerning removing `sub()` calls for versions of julia after 0.4. I'm not sure what course of action would be best since there  it seems that there was already something in the works.

As I have it now, one of the tests is failing due to a call to `sub()`. Most of this is unaffected by usage of `sub()`.